### PR TITLE
Fix scheduled exercise date handling

### DIFF
--- a/SportApp2/src/components/Training/AddExerciseModal.tsx
+++ b/SportApp2/src/components/Training/AddExerciseModal.tsx
@@ -51,6 +51,12 @@ export function AddExerciseModal({
     }
   }, [opened, exercises.length, fetchExercises]);
 
+  useEffect(() => {
+    if (opened) {
+      setDate(selectedDate || null);
+    }
+  }, [opened, selectedDate]);
+
   const filteredExercises = useMemo(() => {
     let filtered = exercises;
     if (searchQuery) {

--- a/SportApp2/src/components/Training/TrainingPage.tsx
+++ b/SportApp2/src/components/Training/TrainingPage.tsx
@@ -167,6 +167,10 @@ export function TrainingPage() {
 
   const currentDays = generateCalendarDays();
 
+  const filteredExercises = scheduledExercises.filter(
+    (exercise) => exercise.workoutDate === formatDateForComparison(selectedDate)
+  );
+
   return (
     <Box style={{ height: '100%' }}>
       <Box p="md">
@@ -303,18 +307,18 @@ export function TrainingPage() {
                 >
                   <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
                     <Text style={{ fontSize: '12px', color: '#888' }}>УПР</Text>
-                    <Text style={{ fontSize: '14px', fontWeight: 500 }}>{scheduledExercises.length}</Text>
+                    <Text style={{ fontSize: '14px', fontWeight: 500 }}>{filteredExercises.length}</Text>
                   </div>
                   <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
                     <Text style={{ fontSize: '12px', color: '#888' }}>ПОДХОДЫ</Text>
                     <Text style={{ fontSize: '14px', fontWeight: 500 }}>
-                      {scheduledExercises.reduce((acc, exercise) => acc + exercise.sets, 0)}
+                      {filteredExercises.reduce((acc, exercise) => acc + exercise.sets, 0)}
                     </Text>
                   </div>
                   <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
                     <Text style={{ fontSize: '12px', color: '#888' }}>КГ</Text>
                     <Text style={{ fontSize: '14px', fontWeight: 500 }}>
-                      {scheduledExercises.reduce((acc, exercise) =>
+                      {filteredExercises.reduce((acc, exercise) =>
                         acc + ((exercise.weight || 0) * exercise.reps * exercise.sets), 0)}
                     </Text>
                   </div>
@@ -342,7 +346,7 @@ export function TrainingPage() {
               Загрузка...
             </Text>
           )}
-          {scheduledExercises.map((exercise) => (
+          {filteredExercises.map((exercise) => (
             <Card
               key={exercise.id}
               style={{
@@ -399,7 +403,7 @@ export function TrainingPage() {
             </Card>
           ))}
 
-          {!loading && scheduledExercises.length === 0 && (
+          {!loading && filteredExercises.length === 0 && (
             <Text c="dimmed" ta="center" py="xl">
               Нет упражнений на выбранную дату
             </Text>

--- a/SportApp2/src/store/useScheduledExercisesStore.ts
+++ b/SportApp2/src/store/useScheduledExercisesStore.ts
@@ -111,7 +111,9 @@ export const useScheduledExercisesStore = create<ScheduledExercisesState>((set, 
       set({ loading: true, error: null });
       const exercise = await scheduledExercisesApi.create(exerciseData);
       set((state) => ({
-        exercises: [...state.exercises, exercise],
+        exercises: state.currentDate === exercise.workoutDate
+          ? [...state.exercises, exercise]
+          : state.exercises,
         loading: false
       }));
       return true;

--- a/SportApp2/src/utils/helpers.ts
+++ b/SportApp2/src/utils/helpers.ts
@@ -1,13 +1,20 @@
 // Утилиты для работы с датами
+const formatLocalDate = (date: Date): string => {
+  const year = date.getFullYear();
+  const month = `${date.getMonth() + 1}`.padStart(2, '0');
+  const day = `${date.getDate()}`.padStart(2, '0');
+  return `${year}-${month}-${day}`;
+};
+
 export const formatDateForAPI = (date: Date): string => {
-  return date.toISOString().split('T')[0];
+  return formatLocalDate(date);
 };
 
 export const formatDateForComparison = (date: Date | string): string => {
   if (typeof date === 'string') {
     return date;
   }
-  return date.toISOString().split('T')[0];
+  return formatLocalDate(date);
 };
 
 // Сравнение дат в формате YYYY-MM-DD


### PR DESCRIPTION
### Motivation
- Prevent UTC-based day shifts when formatting dates for storage and comparison. 
- Avoid appending newly created scheduled exercises into the wrong date view in the store. 
- Keep the add-exercise modal date synchronized with the selected calendar day so added items go to the intended date.

### Description
- Added `formatLocalDate` and switched `formatDateForAPI` and `formatDateForComparison` to use it to produce `YYYY-MM-DD` in local time (`SportApp2/src/utils/helpers.ts`).
- Updated `addExercise` logic to append the created exercise to the in-memory list only when `state.currentDate === exercise.workoutDate` to avoid showing items for other days (`SportApp2/src/store/useScheduledExercisesStore.ts`).
- Synced modal date on open by setting the modal `date` from `selectedDate` in `AddExerciseModal` (`SportApp2/src/components/Training/AddExerciseModal.tsx`).
- Filtered the training list and aggregated stats by `selectedDate` via a `filteredExercises` view and replaced usages of `scheduledExercises` with `filteredExercises` where appropriate (`SportApp2/src/components/Training/TrainingPage.tsx`).

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6989941f8ed8832e8b5e07bad2f7e331)