### PR TITLE
Remove duplicated /api prefix in frontend auth requests

### DIFF
--- a/SportApp2/src/api/auth.ts
+++ b/SportApp2/src/api/auth.ts
@@ -10,24 +10,24 @@ export interface AuthResponse {
 export const authApi = {
   // Вход в систему
   login: async (credentials: LoginRequest): Promise<AuthResponse> => {
-    const response = await apiClient.post<AuthResponse>('/api/auth/login', credentials);
+    const response = await apiClient.post<AuthResponse>('/auth/login', credentials);
     return response.data;
   },
 
   // Регистрация нового пользователя
   register: async (userData: RegisterRequest): Promise<AuthResponse> => {
-    const response = await apiClient.post<AuthResponse>('/api/auth/register', userData);
+    const response = await apiClient.post<AuthResponse>('/auth/register', userData);
     return response.data;
   },
 
   // Получение информации о текущем пользователе
   getCurrentUser: async (): Promise<User> => {
-    const response = await apiClient.get<User>('/api/auth/me');
+    const response = await apiClient.get<User>('/auth/me');
     return response.data;
   },
 
   // Выход из системы
   logout: async (): Promise<void> => {
-    await apiClient.post('/api/auth/logout');
+    await apiClient.post('/auth/logout');
   }
 };

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,7 +51,7 @@ services:
       - "80:80"
       - "443:443"
     environment:                      
-      - VITE_API_URL=https://veretest.online
+      - VITE_API_URL=https://veretest.online/api
     volumes:
       - certbot-www:/var/www/certbot
       - certbot-etc:/etc/letsencrypt


### PR DESCRIPTION
### Motivation
- The frontend was producing URLs like `/api/api/...` because `apiClient.baseURL` (from `VITE_API_URL` or fallback `/api`) was combined with endpoint paths that already contained a leading `/api`.
- The goal is to ensure requests resolve to `https://veretest.online/api/auth/register` so the nginx proxy `location /api/` forwards them to the backend without adding or duplicating `/api`.

### Description
- Removed the hardcoded `/api` prefix from auth endpoints in `SportApp2/src/api/auth.ts` so endpoints use `'/auth/*'` relative to the Axios `baseURL` (changed `'/api/auth/register'` → `'/auth/register'`, etc.).
- Updated the frontend environment in `docker-compose.yml` to `VITE_API_URL=https://veretest.online/api` so `apiClient` resolves to the correct full domain path in production.
- Left the `apiClient` creation in `SportApp2/src/api/client.ts` intact (`baseURL: import.meta.env.VITE_API_URL || '/api'`) and verified nginx `location /api/ { proxy_pass http://backend_upstream; }` is correct so no proxy rewrite changes were required.
- Files changed: `SportApp2/src/api/auth.ts` and `docker-compose.yml` (frontend env update).

### Testing
- Searched codebase for usages with `rg` to confirm all `/api/auth` occurrences were updated, and that `VITE_API_URL` was adjusted, and the search succeeded.
- Built the frontend with `npm run build` in `SportApp2` and the build completed successfully.
- Verified changes were committed to the repo (`git commit`) and a PR description was created; all automated steps above succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699df6cb3188832e866b5bf187a464ee)