### PR TITLE
Split security config by profile to enable H2 console in dev

### DIFF
--- a/sport-app-backend/src/main/java/com/sportapp/config/SecurityConfig.java
+++ b/sport-app-backend/src/main/java/com/sportapp/config/SecurityConfig.java
@@ -2,9 +2,10 @@ package com.sportapp.config;
 
 import com.sportapp.security.JwtAuthenticationEntryPoint;
 import com.sportapp.security.JwtRequestFilter;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Profile;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
@@ -16,6 +17,7 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
@@ -27,6 +29,8 @@ import java.util.List;
 @EnableMethodSecurity
 @EnableConfigurationProperties(CorsProperties.class)
 public class SecurityConfig {
+
+    private static final AntPathRequestMatcher H2_CONSOLE_MATCHER = new AntPathRequestMatcher("/h2-console/**");
 
     private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
     private final JwtRequestFilter jwtRequestFilter;
@@ -54,6 +58,7 @@ public class SecurityConfig {
     }
 
     @Bean
+    @Profile("prod")
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
         configuration.setAllowedOriginPatterns(corsProperties.allowedOriginPatterns());
@@ -67,7 +72,30 @@ public class SecurityConfig {
     }
 
     @Bean
-    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+    @Profile("dev")
+    public SecurityFilterChain devFilterChain(HttpSecurity http) throws Exception {
+        http.cors(AbstractHttpConfigurer::disable)
+            .csrf(AbstractHttpConfigurer::disable)
+            .authorizeHttpRequests(authz -> authz
+                .requestMatchers(H2_CONSOLE_MATCHER).permitAll()
+                .requestMatchers("/api/auth/**").permitAll()
+                .anyRequest().authenticated()
+            )
+            .headers(headers -> headers.frameOptions(frameOptions -> frameOptions.sameOrigin()))
+            .exceptionHandling(ex -> ex
+                .authenticationEntryPoint(jwtAuthenticationEntryPoint)
+            )
+            .sessionManagement(session -> session
+                .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+            );
+
+        http.addFilterBefore(jwtRequestFilter, UsernamePasswordAuthenticationFilter.class);
+        return http.build();
+    }
+
+    @Bean
+    @Profile("prod")
+    public SecurityFilterChain prodFilterChain(HttpSecurity http) throws Exception {
         http.cors(cors -> cors.configurationSource(corsConfigurationSource()))
             .csrf(AbstractHttpConfigurer::disable)
             .authorizeHttpRequests(authz -> authz
@@ -82,7 +110,6 @@ public class SecurityConfig {
             );
 
         http.addFilterBefore(jwtRequestFilter, UsernamePasswordAuthenticationFilter.class);
-
         return http.build();
     }
 }


### PR DESCRIPTION
### Motivation
- Prevent conflicts between the H2 console servlet (`/h2-console/**`) and the main Spring MVC servlet by isolating H2-specific security behavior to the development profile.
- Ensure development convenience (H2 console access and open auth endpoints) does not weaken production security by scoping changes with `@Profile`.

### Description
- Added a `dev`-only `SecurityFilterChain` (`@Profile("dev")`) that disables CORS, disables CSRF, permits `/h2-console/**` and `/api/auth/**`, and sets `X-Frame-Options` to `SAMEORIGIN` so the H2 console can render in an iframe.
- Added a separate `prod` `SecurityFilterChain` (`@Profile("prod")`) that uses the existing CORS configuration and keeps the stricter production rules for other requests.
- Scoped the `CorsConfigurationSource` bean to `prod` with `@Profile("prod")` so development no longer uses the production CORS bean.
- Used an explicit `AntPathRequestMatcher` for the H2 console path to avoid servlet-matching ambiguity that caused the conflict between the H2 console servlet and the MVC servlet.

### Testing
- Attempted to compile the backend with `mvn -f sport-app-backend/pom.xml -DskipTests compile`, but the build failed due to dependency resolution errors (Maven Central returned `403 Forbidden`) in this environment, so full compile verification could not be completed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a3efd9fa80832e83d9a6882060ad40)