### PR TITLE
Configure Vite environment-based API URLs

### DIFF
--- a/SportApp2/.env.development
+++ b/SportApp2/.env.development
@@ -1,0 +1,1 @@
+VITE_API_URL=http://localhost:8080

--- a/SportApp2/.env.production
+++ b/SportApp2/.env.production
@@ -1,0 +1,1 @@
+VITE_API_URL=https://veretest.online

--- a/SportApp2/src/api/auth.ts
+++ b/SportApp2/src/api/auth.ts
@@ -10,24 +10,24 @@ export interface AuthResponse {
 export const authApi = {
   // Вход в систему
   login: async (credentials: LoginRequest): Promise<AuthResponse> => {
-    const response = await apiClient.post<AuthResponse>('/auth/login', credentials);
+    const response = await apiClient.post<AuthResponse>('/api/auth/login', credentials);
     return response.data;
   },
 
   // Регистрация нового пользователя
   register: async (userData: RegisterRequest): Promise<AuthResponse> => {
-    const response = await apiClient.post<AuthResponse>('/auth/register', userData);
+    const response = await apiClient.post<AuthResponse>('/api/auth/register', userData);
     return response.data;
   },
 
   // Получение информации о текущем пользователе
   getCurrentUser: async (): Promise<User> => {
-    const response = await apiClient.get<User>('/auth/me');
+    const response = await apiClient.get<User>('/api/auth/me');
     return response.data;
   },
 
   // Выход из системы
   logout: async (): Promise<void> => {
-    await apiClient.post('/auth/logout');
+    await apiClient.post('/api/auth/logout');
   }
 };

--- a/SportApp2/src/api/client.ts
+++ b/SportApp2/src/api/client.ts
@@ -1,38 +1,40 @@
 import axios from 'axios';
 
+const apiBaseUrl = import.meta.env.VITE_API_URL;
+
+if (!apiBaseUrl) {
+  throw new Error('VITE_API_URL is not defined. Check your .env files.');
+}
+
 export const apiClient = axios.create({
-  baseURL: import.meta.env.VITE_API_URL || '/api',
+  baseURL: apiBaseUrl,
   timeout: 10000,
   headers: {
     'Content-Type': 'application/json',
   },
 });
 
-// Request interceptor для добавления токена
 apiClient.interceptors.request.use(
   (config) => {
     const token = localStorage.getItem('token');
+
     if (token) {
       config.headers = config.headers || {};
       config.headers.Authorization = `Bearer ${token}`;
     }
+
     return config;
   },
-  (error) => {
-    return Promise.reject(error);
-  }
+  (error) => Promise.reject(error)
 );
 
-// Response interceptor для обработки ошибок
 apiClient.interceptors.response.use(
   (response) => response,
   (error) => {
     if (error.response?.status === 401) {
-      // Удаляем токен только при 401 ошибке
       localStorage.removeItem('token');
-      // Можно добавить перенаправление на страницу логина
-      // window.location.href = '/login';
     }
+
     return Promise.reject(error);
   }
 );

--- a/SportApp2/vite.config.ts
+++ b/SportApp2/vite.config.ts
@@ -1,18 +1,27 @@
-// vite.config.ts
 import { defineConfig } from 'vitest/config';
 import react from '@vitejs/plugin-react';
 
-export default defineConfig({
+export default defineConfig(({ mode }) => ({
   plugins: [react()],
   css: {
     modules: {
       localsConvention: 'camelCase',
     },
   },
+  server: mode === 'development'
+    ? {
+        proxy: {
+          '/api': {
+            target: 'http://localhost:8080',
+            changeOrigin: true,
+          },
+        },
+      }
+    : undefined,
   test: {
     environment: 'jsdom',
     setupFiles: ['./src/test/setup.ts'],
     include: ['src/**/*.test.{ts,tsx}'],
     exclude: ['e2e/**', 'node_modules/**', 'dist/**'],
   },
-});
+}));


### PR DESCRIPTION
### Motivation
- Provide a single, environment-driven API base URL so frontend uses `http://localhost:8080` in development and `https://veretest.online` in production.
- Remove hardcoded hosts from the HTTP client and ensure predictable behavior across `npm run dev` and `npm run build` modes.
- Offer an optional local proxy to simplify development and avoid CORS issues when calling relative `/api` routes.

### Description
- Added environment files `SportApp2/.env.development` and `SportApp2/.env.production` with `VITE_API_URL=http://localhost:8080` and `VITE_API_URL=https://veretest.online` respectively so Vite exposes the correct value via `import.meta.env.VITE_API_URL`.
- Rewrote `SportApp2/src/api/client.ts` to use `const apiBaseUrl = import.meta.env.VITE_API_URL` as the `axios` `baseURL`, and fail fast with an error if the variable is not defined, while preserving request/response interceptors (attach `Authorization` header and handle `401`).
- Updated API calls in `SportApp2/src/api/auth.ts` to use the `/api/auth/*` routes (e.g. `POST /api/auth/login`) so requests are consistent with the backend and proxying rules.
- Updated `SportApp2/vite.config.ts` to a mode-aware config and added an optional dev `server.proxy` mapping that forwards `/api` to `http://localhost:8080` when `mode === 'development'`.

### Testing
- Ran a production build with `cd SportApp2 && npm run build`, which completed successfully and produced the `dist` output without build errors.
- No unit tests were modified; the change was validated by a successful TypeScript build (`tsc -b`) and Vite production build during the `npm run build` run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a3f6a2bdd8832e9049b7c079ce920c)