### PR TITLE
Add dev-only superadmin auto-creation at startup

### DIFF
--- a/sport-app-backend/src/main/java/com/sportapp/SportAppApplication.java
+++ b/sport-app-backend/src/main/java/com/sportapp/SportAppApplication.java
@@ -2,8 +2,10 @@ package com.sportapp;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 
 @SpringBootApplication
+@ConfigurationPropertiesScan
 public class SportAppApplication {
 
     public static void main(String[] args) {

--- a/sport-app-backend/src/main/java/com/sportapp/config/SuperAdminInitializer.java
+++ b/sport-app-backend/src/main/java/com/sportapp/config/SuperAdminInitializer.java
@@ -1,26 +1,59 @@
 package com.sportapp.config;
 
-import com.sportapp.service.UserService;
-import org.springframework.beans.factory.annotation.Value;
+import com.sportapp.model.Role;
+import com.sportapp.model.User;
+import com.sportapp.repository.UserRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.boot.CommandLineRunner;
+import org.springframework.context.annotation.Profile;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 @Component
+@Profile("dev")
 public class SuperAdminInitializer implements CommandLineRunner {
 
-    private final UserService userService;
+    private static final Logger log = LoggerFactory.getLogger(SuperAdminInitializer.class);
 
-    @Value("${app.superadmin.email:}")
-    private String superAdminEmail;
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final SuperAdminProperties superAdminProperties;
 
-    public SuperAdminInitializer(UserService userService) {
-        this.userService = userService;
+    public SuperAdminInitializer(
+        UserRepository userRepository,
+        PasswordEncoder passwordEncoder,
+        SuperAdminProperties superAdminProperties
+    ) {
+        this.userRepository = userRepository;
+        this.passwordEncoder = passwordEncoder;
+        this.superAdminProperties = superAdminProperties;
     }
 
     @Override
+    @Transactional
     public void run(String... args) {
-        if (superAdminEmail != null && !superAdminEmail.isBlank()) {
-            userService.assignSuperAdminIfConfigured(superAdminEmail);
+        String email = superAdminProperties.email();
+        String rawPassword = superAdminProperties.password();
+
+        if (email == null || email.isBlank() || rawPassword == null || rawPassword.isBlank()) {
+            log.warn("Superadmin auto-creation skipped: email/password is not configured.");
+            return;
         }
+
+        if (userRepository.existsByEmail(email)) {
+            log.info("Superadmin auto-creation skipped: user with email '{}' already exists.", email);
+            return;
+        }
+
+        User superAdmin = new User();
+        superAdmin.setEmail(email);
+        superAdmin.setPassword(passwordEncoder.encode(rawPassword));
+        superAdmin.setName(email);
+        superAdmin.setRole(Role.SUPERD);
+
+        userRepository.save(superAdmin);
+        log.info("Superadmin user '{}' was created successfully.", email);
     }
 }

--- a/sport-app-backend/src/main/java/com/sportapp/config/SuperAdminProperties.java
+++ b/sport-app-backend/src/main/java/com/sportapp/config/SuperAdminProperties.java
@@ -1,0 +1,7 @@
+package com.sportapp.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "app.superadmin")
+public record SuperAdminProperties(String email, String password) {
+}

--- a/sport-app-backend/src/main/java/com/sportapp/service/UserService.java
+++ b/sport-app-backend/src/main/java/com/sportapp/service/UserService.java
@@ -91,16 +91,6 @@ public class UserService implements UserDetailsService {
         return userRepository.save(targetUser);
     }
 
-    @Transactional
-    public void assignSuperAdminIfConfigured(String email) {
-        userRepository.findByEmail(email).ifPresent(user -> {
-            if (user.getRole() != Role.SUPERD) {
-                user.setRole(Role.SUPERD);
-                userRepository.save(user);
-            }
-        });
-    }
-
     private User getCurrentAuthenticatedUser() {
         String email = SecurityContextHolder.getContext().getAuthentication().getName();
         return findByEmail(email);

--- a/sport-app-backend/src/main/resources/application-dev.yml
+++ b/sport-app-backend/src/main/resources/application-dev.yml
@@ -26,7 +26,8 @@ jwt:
 
 app:
   superadmin:
-    email: ${APP_SUPERADMIN_EMAIL:}
+    email: ${APP_SUPERADMIN_EMAIL:admin@example.com}
+    password: ${APP_SUPERADMIN_PASSWORD:admin123}
   security:
     cors:
       allowed-origin-patterns:

--- a/sport-app-backend/src/main/resources/application-prod.yml
+++ b/sport-app-backend/src/main/resources/application-prod.yml
@@ -36,6 +36,7 @@ jwt:
 app:
   superadmin:
     email: ${APP_SUPERADMIN_EMAIL:}
+    password: ${APP_SUPERADMIN_PASSWORD:}
   security:
     cors:
       allowed-origin-patterns:


### PR DESCRIPTION
### Motivation
- Provide an automatic way to seed a superadmin account in local/dev runs so developers have immediate access without manual DB changes.
- Ensure the account is created only for ephemeral dev H2 databases and not in production to avoid security risks.
- Read credentials from configuration with environment-variable overrides and store password securely using the existing `PasswordEncoder`.

### Description
- Add `SuperAdminProperties` (`app.superadmin.email` / `app.superadmin.password`) as a typed configuration binding (`record` annotated with `@ConfigurationProperties`).
- Implement `SuperAdminInitializer` as a `CommandLineRunner` bean annotated with `@Profile("dev")` that reads `SuperAdminProperties`, skips if email/password are missing, checks `userRepository.existsByEmail(email)` to be idempotent, hashes password with `PasswordEncoder`, sets `Role.SUPERD`, persists the user and logs creation or skip messages.
- Enable `@ConfigurationPropertiesScan` in `SportAppApplication` to wire the typed properties.
- Add default env-variable-backed values to `application-dev.yml` (`APP_SUPERADMIN_EMAIL:admin@example.com` and `APP_SUPERADMIN_PASSWORD:admin123`) and leave `application-prod.yml` properties empty while the initializer remains inactive in `prod` due to `@Profile("dev")`.
- Remove the old `assignSuperAdminIfConfigured` method from `UserService` since initialization responsibility moved to the startup component.

### Testing
- Attempted to run backend automated tests with `mvn -q test`, but the run failed due to dependency resolution being blocked in the environment (Maven Central returned HTTP 403), so no test suite results are available.
- Verified repository changes and commit were created successfully with `git status` and the diff producing the described modifications.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5dd197028832e9e58bd0100fd87c0)